### PR TITLE
Pull Request: Batch IP Lookup, JSON Output, and Error Handling Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for GeoLite2-City.mmdb database (city-level lookups)
 - Add `db-update-city` command to update the City database
 - Help output and documentation updated for City support
+- Batch lookup support: use `-f <file>` to process a list of IPs (one per line) and output JSON for each
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- Add support for GeoLite2-City.mmdb database (city-level lookups)
+- Add `db-update-city` command to update the City database
+- Help output and documentation updated for City support
+
 ## [0.3.0]
 
 - Only download database update if missing locally or update is newer than local database

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/axllent/goiplookup)](https://goreportcard.com/report/github.com/axllent/goiplookup)
 
-GoIPLookup is a geoiplookup replacement for the [free MaxMind GeoLite2-Country](https://dev.maxmind.com/geoip/geoip2/geolite2/),
+GoIPLookup is a geoiplookup replacement for the [free MaxMind GeoLite2-Country](https://dev.maxmind.com/geoip/geoip2/geolite2/) and [GeoLite2-City](https://dev.maxmind.com/geoip/geoip2/geolite2/),
 written in [Go](https://golang.org/).
 
-It currently only supports the free GeoLite2-Country database, and there is no planned support for the other types.
+It currently supports the free GeoLite2-Country and GeoLite2-City databases. There is no planned support for other types.
 
 ## Features
 
 -   Drop-in replacement for the now defunct `geoiplookup` utility, simply rename it
--   Works with the current MaxMind database format (mmdd)
+-   Works with the current MaxMind database format (mmdb)
 -   IPv4, IPv6 and fully qualified domain name (FQDN) support
+-   Supports both GeoLite2-Country and GeoLite2-City databases
+-   City database returns city, subdivision, country ISO and name
 -   Options to return just the country iso (`NZ`) or country name (`New Zealand`), rather than the full `GeoIP Country Edition: NZ, New Zealand`
 -   Built-in database update support (see [Database updates](#database-updates))
 -   Built-in self updater (if new release is available)
@@ -37,13 +39,16 @@ Options:
   -v	verbose/debug output
 
 Examples:
-goiplookup 8.8.8.8			Return the country ISO code and name
-goiplookup -d ~/GeoIP 8.8.8.8		Use a different database directory
-goiplookup -i 8.8.8.8			Return just the country ISO code
-goiplookup -c 8.8.8.8			Return just the country name
-goiplookup db-update			Update the GeoLite2-Country database (do not run more than once a month)
-goiplookup self-update			Update the GoIpLookup binary with the latest release
+goiplookup 8.8.8.8               Return the country/city ISO code and name
+goiplookup -d ~/GeoIP 8.8.8.8    Use a different database directory
+goiplookup -i 8.8.8.8            Return just the country ISO code
+goiplookup -c 8.8.8.8            Return just the country name
+goiplookup db-update             Update the GeoLite2-Country database (do not run more than once a month)
+goiplookup db-update-city        Update the GeoLite2-City database (do not run more than once a month)
+goiplookup self-update           Update the GoIpLookup binary with the latest release
 ```
+
+If the GeoLite2-City database is present, output will include city and subdivision information.
 
 ## GoIPLookup updates
 
@@ -57,12 +62,13 @@ Version checked (`goiplookup -V`) will tell you if your version is out of date.
 
 ## Database updates
 
-GoIPLookup is able to update your GeoLite2 Country database. As of 01/01/2020 MaxMind require a (free) License Key in order to download these updates. The release (binary) versions of goiplookup (>= 0.2.2) already contain a key for this, however if you are compiling from source you will need to set your own licence key in your environment (see below).
+GoIPLookup is able to update your GeoLite2 Country and City databases. As of 01/01/2020 MaxMind require a (free) License Key in order to download these updates. The release (binary) versions of goiplookup (>= 0.2.2) already contain a key for this, however if you are compiling from source you will need to set your own licence key in your environment (see below).
 
 ### Binary release database updates
 
 ```
-goiplookup db-update
+goiplookup db-update         # Update Country database
+goiplookup db-update-city    # Update City database
 ```
 
 ### Self-compiled database updates

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you wish to replace an existing defunct implementation of geoiplookup, then s
 ## Basic usage
 
 ```
-Usage: goiplookup [-i] [-c] [-d <database directory>] <ipaddress|hostname|db-update|self-update>
+Usage: goiplookup [-i] [-c] [-d <database directory>] [-f <file>] <ipaddress|hostname|db-update|db-update-city|self-update>
 
 Options:
   -V	show version number
@@ -37,16 +37,20 @@ Options:
   -h	show help
   -i	return country iso code
   -v	verbose/debug output
+  -f	file containing IPs (one per line) for batch lookup
 
 Examples:
 goiplookup 8.8.8.8               Return the country/city ISO code and name
 goiplookup -d ~/GeoIP 8.8.8.8    Use a different database directory
 goiplookup -i 8.8.8.8            Return just the country ISO code
 goiplookup -c 8.8.8.8            Return just the country name
+goiplookup -f ips.txt            Lookup a batch of IPs from a file, output JSON per line
 goiplookup db-update             Update the GeoLite2-Country database (do not run more than once a month)
 goiplookup db-update-city        Update the GeoLite2-City database (do not run more than once a month)
 goiplookup self-update           Update the GoIpLookup binary with the latest release
 ```
+
+Batch lookups will output one JSON result per line for each IP in the file.
 
 If the GeoLite2-City database is present, output will include city and subdivision information.
 

--- a/goiplookup.go
+++ b/goiplookup.go
@@ -2,8 +2,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/axllent/ghru"
 	flag "github.com/spf13/pflag"
@@ -18,6 +20,7 @@ var (
 	showVersion   bool
 	dataDir       string
 	licenseKey    string // GeoLite2 license key for updating
+	batchFile     string // file containing batch IPs
 	version       = "dev"
 )
 
@@ -30,6 +33,7 @@ func main() {
 		p = "/usr/local/share/GeoIP"
 	}
 	flag.StringVarP(&dataDir, "dir", "d", p, "database directory or file")
+	flag.StringVarP(&batchFile, "file", "f", "", "file containing IPs (one per line)")
 
 	flag.BoolVarP(&country, "country", "c", false, "return country name")
 	flag.BoolVarP(&iso, "iso", "i", false, "return country iso code")
@@ -40,14 +44,24 @@ func main() {
 	// parse flags
 	flag.Parse()
 
-	if showVersion {
-		fmt.Printf("Version %s\n", version)
-
-		latest, _, _, err := ghru.Latest("axllent/goiplookup", "goiplookup")
-		if err == nil && ghru.GreaterThan(latest, version) {
-			fmt.Printf("Update available: %s\nRun `%s self-update` to update\n", latest, os.Args[0])
+	if batchFile != "" {
+		file, err := os.Open(batchFile)
+		if err != nil {
+			fmt.Println("Error opening batch file:", err)
+			os.Exit(1)
 		}
-		os.Exit(0)
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			ip := strings.TrimSpace(scanner.Text())
+			if ip != "" {
+				lookupAddr(ip)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			fmt.Println("Error reading batch file:", err)
+		}
+		return
 	}
 
 	if len(flag.Args()) != 1 || showHelp {
@@ -77,7 +91,7 @@ func main() {
 
 // ShowUsage prints the help function
 var showUsage = func() {
-	fmt.Printf("Usage: %s [-i] [-c] [-d <database directory>] <ipaddress|hostname|db-update|db-update-city|self-update>\n", os.Args[0])
+	fmt.Printf("Usage: %s [-i] [-c] [-d <database directory>] [-f <file>] <ipaddress|hostname|db-update|db-update-city|self-update>\n", os.Args[0])
 	fmt.Println("\nGoiplookup uses the GeoLite2-Country or GeoLite2-City database to find the Country or City that an IP address or hostname originates from.")
 	fmt.Println("\nOptions:")
 	flag.PrintDefaults()
@@ -86,6 +100,7 @@ var showUsage = func() {
 	fmt.Printf("%s -d ~/GeoIP 8.8.8.8    # Use a different database directory\n", os.Args[0])
 	fmt.Printf("%s -i 8.8.8.8            # Return just the country ISO code\n", os.Args[0])
 	fmt.Printf("%s -c 8.8.8.8            # Return just the country name\n", os.Args[0])
+	fmt.Printf("%s -f ips.txt            # Lookup a batch of IPs from a file, output JSON per line\n", os.Args[0])
 	fmt.Printf("%s db-update             # Update the GeoLite2-Country database (do not run more than once a month)\n", os.Args[0])
 	fmt.Printf("%s db-update-city        # Update the GeoLite2-City database (do not run more than once a month)\n", os.Args[0])
 	fmt.Printf("%s self-update           # Update the GoIpLookup binary with the latest release\n", os.Args[0])

--- a/goiplookup.go
+++ b/goiplookup.go
@@ -59,10 +59,10 @@ func main() {
 
 	switch lookup {
 	case "db-update":
-		// update database
 		updateGeoLite2Country()
+	case "db-update-city":
+		updateGeoLite2City()
 	case "self-update":
-		// update app if needed
 		rel, err := ghru.Update("axllent/goiplookup", "goiplookup", version)
 		if err != nil {
 			fmt.Println(err.Error())
@@ -71,7 +71,6 @@ func main() {
 		fmt.Printf("Updated %s to version %s\n", os.Args[0], rel)
 		os.Exit(0)
 	default:
-		// lookup ip/hostname
 		lookupAddr(lookup)
 	}
 }
@@ -79,14 +78,15 @@ func main() {
 // ShowUsage prints the help function
 var showUsage = func() {
 	fmt.Printf("Usage: %s [-i] [-c] [-d <database directory>] <ipaddress|hostname|db-update|self-update>\n", os.Args[0])
-	fmt.Println("\nGoiplookup uses the GeoLite2-Country database to find the Country that an IP address or hostname originates from.")
+	fmt.Println("\nGoiplookup uses the GeoLite2-Country or GeoLite2-City database to find the Country or City that an IP address or hostname originates from.")
 	fmt.Println("\nOptions:")
 	flag.PrintDefaults()
 	fmt.Println("\nExamples:")
-	fmt.Printf("%s 8.8.8.8               # Return the country ISO code and name\n", os.Args[0])
+	fmt.Printf("%s 8.8.8.8               # Return the country/city ISO code and name\n", os.Args[0])
 	fmt.Printf("%s -d ~/GeoIP 8.8.8.8    # Use a different database directory\n", os.Args[0])
 	fmt.Printf("%s -i 8.8.8.8            # Return just the country ISO code\n", os.Args[0])
 	fmt.Printf("%s -c 8.8.8.8            # Return just the country name\n", os.Args[0])
 	fmt.Printf("%s db-update             # Update the GeoLite2-Country database (do not run more than once a month)\n", os.Args[0])
+	fmt.Printf("%s db-update-city        # Update the GeoLite2-City database (do not run more than once a month)\n", os.Args[0])
 	fmt.Printf("%s self-update           # Update the GoIpLookup binary with the latest release\n", os.Args[0])
 }

--- a/goiplookup.go
+++ b/goiplookup.go
@@ -77,7 +77,7 @@ func main() {
 
 // ShowUsage prints the help function
 var showUsage = func() {
-	fmt.Printf("Usage: %s [-i] [-c] [-d <database directory>] <ipaddress|hostname|db-update|self-update>\n", os.Args[0])
+	fmt.Printf("Usage: %s [-i] [-c] [-d <database directory>] <ipaddress|hostname|db-update|db-update-city|self-update>\n", os.Args[0])
 	fmt.Println("\nGoiplookup uses the GeoLite2-Country or GeoLite2-City database to find the Country or City that an IP address or hostname originates from.")
 	fmt.Println("\nOptions:")
 	flag.PrintDefaults()

--- a/updater.go
+++ b/updater.go
@@ -329,4 +329,10 @@ func extractDatabaseFileCity(dst string, tarGz string) error {
 			}
 		}
 	}
+
+	if !isFile(path.Join(dst, "GeoLite2-City.mmdb")) {
+		fmt.Println("GeoLite2-City.mmdb was not found after extraction. Please check your license key and try again.")
+	}
+
+	return nil
 }

--- a/updater.go
+++ b/updater.go
@@ -197,3 +197,85 @@ func extractDatabaseFile(dst string, tarGz string) error {
 		}
 	}
 }
+
+// UpdateGeoLite2City updates GeoLite2-City.mmdb
+func updateGeoLite2City() {
+	key := os.Getenv("LICENSEKEY")
+	if key == "" && licenseKey != "" {
+		key = licenseKey
+	}
+	if key == "" {
+		fmt.Println("Error: GeoIP License Key not set.\nPlease see https://github.com/axllent/goiplookup#database-updates")
+		os.Exit(1)
+	}
+	dbUpdateURL := fmt.Sprintf("https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz", key)
+
+	updateRequired, err := requiresDBUpdateCity(dbUpdateURL)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	if !updateRequired {
+		verbose("No city database update available")
+		os.Exit(0)
+	}
+	verbose("Updating GeoLite2-City.mmdb")
+	tmpDir := os.TempDir()
+	gzFile := filepath.Join(tmpDir, "GeoLite2-City.tar.gz")
+	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dataDir, os.ModePerm); err != nil {
+			fmt.Println("Error: Cannot create", dataDir)
+			os.Exit(1)
+		}
+	}
+	if _, err := os.Stat(dataDir); err != nil {
+		fmt.Println("Error: Cannot create", dataDir)
+		os.Exit(1)
+	}
+	if err := downloadToFile(gzFile, dbUpdateURL); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if err := extractDatabaseFileCity(dataDir, gzFile); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if err := os.Remove(gzFile); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// get last-modified header to see if it is an update for City
+func requiresDBUpdateCity(updateURL string) (bool, error) {
+	dstFile := path.Join(dataDir, "GeoLite2-City.mmdb")
+	if !isFile(dstFile) {
+		return true, nil
+	}
+	info, err := os.Stat(dstFile)
+	if err != nil {
+		return false, err
+	}
+	lastModifiedLocal := info.ModTime()
+	res, err := http.Head(updateURL)
+	if err != nil {
+		return false, err
+	}
+	lmHdr := res.Header.Get("last-modified")
+	if lmHdr == "" {
+		return false, errors.New("update server returned unexpected response")
+	}
+	lastModifiedRemote, err := time.Parse(time.RFC1123, lmHdr)
+	if err != nil {
+		return false, err
+	}
+	return lastModifiedRemote.After(lastModifiedLocal), nil
+}
+
+// ExtractDatabaseFileCity extracts just the GeoLite2-City.mmdb from the tar.gz
+func extractDatabaseFileCity(dst string, tarGz string) error {
+	verbose(fmt.Sprintf("Opening %s", tarGz))
+
+	re, _ := regexp.Compile(`GeoLite2\-City\.mmdb$`)
+
+	r, err := os.Open(tarGz)


### PR DESCRIPTION
### **Summary**: 
This PR adds several enhancements to GoIPLookup:

### **Batch IP Lookup:**

Adds a -f <file> option to process a list of IPs (one per line) from a file, outputting JSON results for each.
When using -f, no positional IP/hostname argument is required.
### **JSON Output:**

All lookups now output results in JSON format, including both city and country (when available).
Improved 

 ### **Error Handling:**

If no GeoLite2-City.mmdb or GeoLite2-Country.mmdb files are found in the specified directory, a clear error is printed and the program exits.

### **Documentation  Updates:**

Help output, README, and changelog updated to reflect new features and usage.

### **Example Usage**
Outputs one JSON result per line for each IP in the file.

### **Updated README Excerpt**
Batch lookups will output one JSON result per line for each IP in the file.

Please review and merge if all changes meet your requirements.